### PR TITLE
Setup geocoder integration with node-geocoder and environment variables

### DIFF
--- a/consumers-api/src/utils/geocoder.js
+++ b/consumers-api/src/utils/geocoder.js
@@ -1,0 +1,12 @@
+const NodeGeocoder = require('node-geocoder');
+
+const options = {
+  provider: process.env.GEOCODER_PROVIDER, 
+  httpAdapter: 'https',
+  apiKey: process.env.GEOCODER_API_KEY,     
+  formatter: null
+};
+
+const geocoder = NodeGeocoder(options);
+
+module.exports = geocoder;


### PR DESCRIPTION
### Summary:
This PR introduces the geocoder integration using the `node-geocoder` package, configured via environment variables for flexibility. A new `geocoder.js` file is created in the `utils` folder to centralize the geocoding setup, making it reusable throughout the app.

### Changes:
- Installed `node-geocoder` package for geocoding functionality.
- Created `utils/geocoder.js` to configure the geocoder instance using environment variables.
- Added `GEOCODER_PROVIDER` and `GEOCODER_API_KEY` to `.env` file for flexible configuration.
- Exported the configured geocoder instance for use in other parts of the application.

### How to test:
1. Ensure the `.env` file contains the correct `GEOCODER_PROVIDER` and `GEOCODER_API_KEY` values.
2. Use the geocoder instance in a service or controller to make a geocoding request (see example in the PR description).

### Notes:
- Make sure the environment variables are set up before using the geocoder in the app.
- If the API key is missing, an error will be thrown.

### Next Steps:
- Integrate geocoder functionality in services or controllers where geocoding is needed.
closes issue #41 