### PR TITLE
feat(auth): add dual registration selection page for consumers and service renders

### DIFF
--- a/frontend/src/pages/reglinks.js
+++ b/frontend/src/pages/reglinks.js
@@ -1,0 +1,136 @@
+import { Box, Container } from "@mui/material";
+import consumer from "../images/consumer.jpg";
+import service from "../images/service2.jpg";
+import { Link } from "react-router-dom";
+
+export const LinksToRegPage = () => {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "center",
+        alignItems: "center",
+        height: "100vh",
+      }}
+    >
+      <Container
+        maxWidth="md"
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 5,
+          margin: "auto",
+        }}
+      >
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "row",
+            gap: 5,
+            border: "1px solid grey",
+          }}
+        >
+          <Box sx={{ maxHeight: "400px", maxWidth: "400px" }}>
+            <img
+              src={consumer}
+              alt="consumer image"
+              width={"100%"}
+              height={"100%"}
+            />
+          </Box>
+          <Box
+            sx={{
+              maxHeight: "400px",
+              maxWidth: "600px",
+              display: "flex",
+              justifyContent: "center",
+              alignItems: "center",
+              textAlign: "center",
+            }}
+          >
+            <h5
+              style={{
+                textDecoration: "none",
+                textAlign: "center",
+                fontSize: "1.5rem",
+                fontFamily: "Roboto,Helvetica,Arial,sans-serif",
+                fontWeight: "400",
+              }}
+            >
+              To Register as a service consumer
+              <br />
+              <Link
+                style={{
+                  textDecoration: "none",
+                  textAlign: "center",
+                  color: "green",
+                  fontSize: "1.7rem",
+                  fontWeight: "400",
+                }}
+                to={"/consumerreg"}
+              >
+                {" "}
+                Click Here
+              </Link>
+            </h5>
+          </Box>
+        </Box>
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "row-reverse",
+            gap: 5,
+            border: "1px solid grey",
+          }}
+        >
+          <Box sx={{ maxHeight: "400px", maxWidth: "400px" }}>
+            <img
+              src={service}
+              alt="consumer image"
+              width={"100%"}
+              height={"100%"}
+            />
+          </Box>
+          <Box
+            sx={{
+              maxHeight: "400px",
+              maxWidth: "600px",
+              display: "flex",
+              justifyContent: "center",
+              alignItems: "center",
+              textAlign: "center",
+            }}
+          >
+            <h5
+              style={{
+                textDecoration: "none",
+                textAlign: "center",
+                fontSize: "1.5rem",
+                fontFamily: "Roboto,Helvetica,Arial,sans-serif",
+                fontWeight: "400",
+              }}
+            >
+              To Register as a service Render
+              <br />
+              <Link
+                style={{
+                  textDecoration: "none",
+                  textAlign: "center",
+                  color: "green",
+                  fontSize: "1.7rem",
+                  fontWeight: "400",
+                }}
+                to={"/renderreg"}
+                state={{ initialPageUrl: window.location.pathname }}
+              >
+                {" "}
+                Click Here
+              </Link>
+            </h5>
+          </Box>
+        </Box>
+      </Container>
+    </Box>
+  );
+};


### PR DESCRIPTION
## Feature: Dual Registration Options Page

This PR implements a user-friendly selection interface that allows new users to register either as a **Service Consumer** or a **Service Render**. Each option is visually distinct and directs users to the appropriate registration form.

### Key Features

- **Two Clear Options**: One section each for "Service Consumer" and "Service Render" registration.
- **Images Included**: 
  - `../images/consumer.jpg` for consumers.
  - `../images/service2.jpg` for renders.
- **Responsive Layout**:
  - Consumer section: image on the left, text on the right.
  - Render section: image on the right, text on the left.
-  **Components Used**:
  - Layout: `Box`, `Container`, and flex utilities from @mui/material.
  - Routing: `Link` from react-router-dom.
- **Styling**:
  - Full-width images with 100% width and height.
  - Flex layout with spacing and responsive breakpoints.
  - Green-colored links with visual emphasis.

### Acceptance Criteria Met

- [x] Page loads without errors and covers full viewport height.
- [x] Two distinct, bordered registration sections are rendered.
- [x] Each section includes an image, descriptive text, and a clickable green link.
- [x] Clicking either link routes to `/renderreg`, with `initialPageUrl` state passed.
- [x] Layout adapts well on various screen sizes.

### Affected Files

- `src/pages/RegistrationChoice.tsx`)

---

### Closes

Closes #75 
